### PR TITLE
Fix pointer to project

### DIFF
--- a/api.go
+++ b/api.go
@@ -132,7 +132,7 @@ func (a *API) GetProjects() (projects Projects, err error) {
 
 // GetProject return the details of a project given a project id
 func (a *API) GetProject(projectID string) (project *Project, err error) {
-	err = a.client.Get("/cloud/project/"+projectID, project)
+	err = a.client.Get("/cloud/project/"+projectID, &project)
 	return project, err
 }
 


### PR DESCRIPTION
We want to provide the address of the project to the client to be able
to unmarshall response with project type
