### PR TITLE
Enable usage of ssh keys present outside docker-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,23 @@ Note: For the different image-types you have to use special --ovh-ssh-user (for 
 |``--ovh-image``                                            |Cloud Machine image|Ubuntu 16.04 |no|
 |``--ovh-ssh-user``                                         |Cloud Machine SSH User|ubuntu |no|
 |``--ovh-project``                                          |Cloud Project name/description or id|single one|only if multiple projects|
+|``--ovh-ssh-key``                                          |Cloud Machine SSH Key|none |no|
 
-Note: OVH credentials may be supplied through arguments, environment or configuration file, by order
-of decreasing priority. The configuration may be:
+Note:
 
-- global ``/etc/ovh.conf``
-- user specific ``~/.ovh.conf``
-- application specific ``./ovh.conf``
+1. OVH credentials
 
+   OVH credentials may be supplied through arguments, environment or configuration file, by order of decreasing priority. The configuration may be:
 
+   - global ``/etc/ovh.conf``
+   - user specific ``~/.ovh.conf``
+   - application specific ``./ovh.conf``
+
+2. SSH key
+
+   Docker-machine can generate a key for each new machine. It is a nice feature to start with but it will quickly load your OVH project with many keys (even though these keys are removed uppon machine deletion).
+
+   With the `--ovh-ssh-key` option you can define a key name (already present in your ovh project). This key must be accessible (in ~/.ssh or in the ssh agent) by the ssh binary present on the machine running docker-mamchine.
 
 ## Hacking
 


### PR DESCRIPTION
We would like to use keys present in ~/.ssh or in an ssh agent.
IOW let ssh send the known keys.
docker-machine enables this feature if the `Driver.SSHKeyPath` is empty
and if we don't use the native ssh client.

If the keypair name assigned doesn't exist in docker-machine, we assume
that this key is present outside docker-machine.
